### PR TITLE
Create Council Minutes & Performance Review - Council #9.md

### DIFF
--- a/Council Minutes & Performance Review - Council #9.md
+++ b/Council Minutes & Performance Review - Council #9.md
@@ -1,0 +1,99 @@
+# Council Performance Review and Minutes
+## 1 - Basic Information
+
+Council #9 blocks: 1,240,4112 (third council)
+
+The council is expected to produce reports during each round and provide feedback in the form of workflow, challenges, thinking and performance as well as minutes covering important events during the council session.
+
+Usernames referenced are Joystream usernames.
+
+## 2 - Minutes
+### 2.1 - Proposals Created
+- Fund the forum sudo account (https://testnet.joystream.org/#/proposals/16)
+     - Forum thread: https://testnet.joystream.org/#/forum/threads/56
+	 - Status: Approved & executed successfully
+	 - Created by: @tomato
+	 - Participants:
+ - Council #8 Report (https://testnet.joystream.org/#/proposals/17)
+	 - Forum Thread: https://testnet.joystream.org/#/forum/threads/49
+	 - Github PR: https://github.com/Joystream/community-repo/pull/5
+	 - Status: Approved
+	 - Created by: @tomato
+	 - Participants: 
+ - Elect a Forum Sudo Key (https://testnet.joystream.org/#/proposals/18)
+	 - Forum Thread: https://testnet.joystream.org/#/forum/threads/56
+	 - Status: Approved
+	 - Created by: @tomato
+	 - Participants: 
+ - 15.06.2020 - Test Proposal Discussion (https://testnet.joystream.org/#/proposals/19)
+	 - Forum Thread: N/A (discussion system was activated, so any proposals after this do not require a dedicated forum thread)
+	 - Status: Approved
+	 - Crated by: @tomato
+	 - Participants: 
+ - 15.06.2020 - Storage Node payment update (https://testnet.joystream.org/#/proposals/20)
+	 - Forum threads: https://testnet.joystream.org/#/forum/threads/57 & https://testnet.joystream.org/#/forum/threads/32
+	 - Status: Passed (pending execution)
+	 - Created by: @tomato
+	 - Participants: 
+ - Replenishing the mind tor ContentCurator (https://testnet.joystream.org/#/proposals/21)
+	 - Forum threads: N/A
+	 - Status: Passed
+	 - Created by: @maks_malensek
+	 - Participants: 
+ - 14.06.2020 council payments (manual) (https://testnet.joystream.org/#/proposals/22)
+	 - Forum threads: https://testnet.joystream.org/#/forum/threads/60
+	 - Status: Pending
+	 - Created by: @tomato
+	 - Participants: 
+
+### 2.2 - Community Repo Pull Requests
+- https://github.com/Joystream/community-repo/pull/5
+- https://testnet.joystream.org/#/forum/threads/49
+	- PR + forum thread created for Council Minutes & Performance Review
+	- Participants: @tomato, @fierydev, freakstatic_council
+
+### 2.3 - Select Forum Activity
+- https://testnet.joystream.org/#/forum/threads/56
+	- Thread created for KPI 4.6 - Forum Sudo
+	- Participants: @tomato
+- https://testnet.joystream.org/#/forum/threads/57
+	- Thread created for discussing storage provider payment updates
+	- Participants: @tomato
+- https://testnet.joystream.org/#/forum/threads/58
+	- Thread created for discussing KPI 4.1 - Block Production
+	- Participants: @tomato, @freakstatic_council
+- https://testnet.joystream.org/#/forum/threads/59
+	- Thread created for discussing this document and soliciting council feedback
+	- Participants: @tomato
+
+### 2.5 - Select events
+- Runtime Updated (proposal discussion system became active)
+	- Proposal: https://testnet.joystream.org/#/proposals/14 (passed during previous council)
+	- Block: 1,279,512
+- Council member payment issues
+	- There are some issues with council payments and they need to be done manually, discussion about this and a proposal were created.
+
+## 3 - Review
+### 3.1 - Workflow
+@tomato
+During this council round, the proposal discussion system was activated which makes the council's processes a lot more streamlined. Most of the workflow for now involves trying to create a discussion regarding proposals and then finally creating proposals and trying to get the council to vote in a timely fashion.
+### 3.2 - Challenges & Thinking
+@tomato
+For this round of the council it was very difficult to get the majority of the council to vote on proposals in a timely fashion, however no proposals failed due to a lack of votes, but it could still be improved. This was probably due to the poor turnout (10 applicants for 10 seats) for the previous election and perhaps newer members of the council are not fully aware of the council's role on the platform. Besides activity of members some of the KPIs were difficult to achieve within the timeframes expected.
+### 3.3 - Performance
+@tomato
+Overall the council did well this round in creating proposals and communicating across various mediums (forum & Telegram chat). Unfortunately we missed some KPIs this session due to various reasons.
+
+## 4 - Obligations
+Council obligations are payments or items that carry through council sessions. These are noted so that future councils can easily see what items they should be aware of. Items can be removed from here once they have been resolved or become outdated.
+### 4.1 Regular Payments / Proposals
+- Council Mint
+	- The council mint needs to be checked on a regular basis and in the event it is near depletion, a council member should notify a member of Jsgenesis in order for it to be refilled.
+	- The council mint is set at a value decided by Jsgenesis.
+- Content Curator Mint
+	- The Content Curator Mint currently has a maximum value of 1 million tokens.
+	- The Content Curator Mint has to be filled periodically and the agreed amount was discussed earlier. The amount may change in the future, but the rewards for this role are dependent on the council passing these proposals in a timely fashion.
+	- The Content Curator Lead role is expected to keep track of their mint level and any member of the Joystream platform can create a proposal to refill this mint.
+### 4.2 Bounties
+- Forum Telegram Bot Bounty ($60)
+	- This was already coded and implemented but the author has not yet created a spending propsal to collect their reward. The author should commit the code to Joystream community repo when they are ready to collect the reward. (https://testnet.joystream.org/#/forum/threads/33)


### PR DESCRIPTION
Compared to the previous report, I added a section for obligations which will be a good addition so that future council's can understand reoccurring tasks and preexisting obligations (like paying bounties).
This is still a WIP, but will create a proposal for its addition after this council session ends.
Participants from proposals and forum threads still needs to be added.